### PR TITLE
MOVE-4407 Erstattet Dumbster med GreenMail

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -258,10 +258,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <!-- FIXME com.github.kirviq:dumbster:1.7.1   17 Jul 2016 at 13:19 (CEST) -->
-            <groupId>com.github.kirviq</groupId>
-            <artifactId>dumbster</artifactId>
-            <version>1.7.1</version>
+            <groupId>com.icegreen</groupId>
+            <artifactId>greenmail</artifactId>
+            <version>2.1.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/no/difi/move/kosmos/cucumber/CucumberStepsConfiguration.java
+++ b/src/test/java/no/difi/move/kosmos/cucumber/CucumberStepsConfiguration.java
@@ -1,7 +1,8 @@
 package no.difi.move.kosmos.cucumber;
 
-import com.dumbster.smtp.SimpleSmtpServer;
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.icegreen.greenmail.util.GreenMail;
+import com.icegreen.greenmail.util.ServerSetupTest;
 import io.cucumber.java.After;
 import io.cucumber.java.Before;
 import io.cucumber.spring.CucumberContextConfiguration;
@@ -65,8 +66,10 @@ public class CucumberStepsConfiguration {
 
         @Bean
         @SneakyThrows
-        public SimpleSmtpServer simpleSmtpServer() {
-            return SimpleSmtpServer.start(SimpleSmtpServer.AUTO_SMTP_PORT);
+        public GreenMail testSmtpServer() {
+            var smtpServer = new GreenMail(ServerSetupTest.SMTP.dynamicPort());
+            smtpServer.start();
+            return smtpServer;
         }
 
         @Bean


### PR DESCRIPTION
Byttet ut Dumbster (sist oppdatert i 2016) med GreenMail.
Samme har vært gjort med ELMA og Integrasjonspunktet tidligere.